### PR TITLE
Add data-driven research pages with preview section

### DIFF
--- a/_includes/research_preview_section.html
+++ b/_includes/research_preview_section.html
@@ -1,0 +1,52 @@
+{% comment %}
+Renders exactly 3 featured areas (or first 3 by order if none featured).
+Uses existing _data/research/*.yml files.
+{% endcomment %}
+
+{% assign areas = "" | split: "" %}
+{% for pair in site.data.research %}
+  {% assign area = pair[1] %}
+  {% assign areas = areas | push: area %}
+{% endfor %}
+{% assign featured = areas | where: "featured", true | sort: "order" %}
+{% if featured.size == 0 %}
+  {% assign featured = areas | sort: "order" | slice: 0,3 %}
+{% else %}
+  {% assign featured = featured | slice: 0,3 %}
+{% endif %}
+
+<section class="research-preview reveal-on-scroll" id="research-preview">
+  {% if include.title != false %}
+    <h2 class="rp-title">{{ include.title | default: "Research Preview" }}</h2>
+  {% endif %}
+  <div class="preview-grid">
+    {% for a in featured %}
+      <article class="preview-card">
+        {% if a.image %}
+          <img src="{{ a.image }}" alt="{{ a.title }}">
+        {% endif %}
+        <h3>{{ a.title }}</h3>
+        <p class="blurb">
+          {% if a.preview_blurb %}{{ a.preview_blurb }}{% else %}{{ a.summary | truncate: 140 }}{% endif %}
+        </p>
+        {% assign overview = a.links | where: "text", "Overview" | first %}
+        {% if overview %}
+          <a class="cta" href="{{ overview.url }}">Know more →</a>
+        {% else %}
+          <a class="cta" href="/research/#{{ a.key }}">Know more →</a>
+        {% endif %}
+      </article>
+    {% endfor %}
+  </div>
+</section>
+
+<style>
+.research-preview { margin: 2rem 0; }
+.rp-title { margin: 0 0 .75rem; }
+.preview-grid { display:grid; gap:1.25rem; grid-template-columns:repeat(auto-fit, minmax(260px,1fr)); }
+.preview-card { border:1px solid #eee; border-radius:14px; padding:1rem; background:#fff; }
+.preview-card img { width:100%; height:150px; object-fit:cover; border-radius:10px; margin-bottom:.5rem; }
+.preview-card h3 { margin:.25rem 0 .35rem; }
+.blurb { margin:0 0 .65rem; }
+.cta { display:inline-block; text-decoration:none; border:1px solid #111; border-radius:10px; padding:.4rem .7rem; }
+</style>

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -60,6 +60,8 @@ Our mantra encapsulates our commitment to:
 * Empowering our members through modern AI-aided practices and open-source workflows.
 
 
+{% include research_preview_section.html title=false %}
+
 ***SSA UPDATES***
 * SSA 2024 **[Denolle et al, 2024: SCOPED Update](https://docs.google.com/presentation/d/1QL_yfaMfcH_zC1mIyAlHTM2ms2FX8yAN22WpA-l_suY/edit?usp=drive_link)**
 
@@ -78,3 +80,23 @@ Group Presentations to conferences
 We are located in Seattle, WA, at the University of Washington, in the heart of the Pacific Northwest (PNW). The PNW is a wonderful natural laboratory to monitor earthquakes, landslides, volcanoes, glaciers, and more broadly speaking the subduction-zone environment.
 
  **We are looking for new graduate students, postdocs, and undergraduate researcher** [(more info)]({{ site.url }}{{ site.baseurl }}/openings) **!**
+
+<script>
+(function(){
+  const els = document.querySelectorAll('.reveal-on-scroll');
+  const obs = new IntersectionObserver((entries)=>{
+    entries.forEach(e=>{
+      if(e.isIntersecting){
+        e.target.classList.add('revealed');
+        obs.unobserve(e.target);
+      }
+    });
+  }, { threshold: 0.15 });
+  els.forEach(el=>obs.observe(el));
+})();
+</script>
+<style>
+.reveal-on-scroll { opacity: 0; transform: translateY(12px); transition: opacity .5s ease, transform .5s ease; }
+.reveal-on-scroll.revealed { opacity: 1; transform: none; }
+</style>
+

--- a/_pages/research-preview.md
+++ b/_pages/research-preview.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: Research Preview
+permalink: /research/preview/
+---
+
+{% include research_preview_section.html %}

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -1,37 +1,92 @@
 ---
-title: "Denolle Lab - Research"
-layout: textlay
-excerpt: "Denolle Lab -- Research"
-sitemap: false
+layout: page
+title: Research
 permalink: /research/
 ---
 
-# Research
+<p class="lead">Our main areas of research. Click through for overviews, people, and recent work.</p>
 
-[**Ambient Noise Seismology**](/research/ambient-noise-seismology)
-We use 100s of TB of ambient seismic noise from seismic stations, cross correlate signals using single and multiple station approaches to get a time-dependent estimate of the Earth response. We use these estimates to **predict ground motions** for future earthquakes and image the Earth subsurface. We also use their time dependence evaluate the **changes in the subsurface** due to effects ranging from **earthquake damage** (short time scales), seasonal climate effects, and **long-term hydrological effects**. 
+<!-- Tag Filter Controls (auto-built from all tags) -->
+<div id="tag-filter" class="tag-filter">
+  <button class="tag-btn active" data-tag="__all">All</button>
+  {% assign all_tags = "" | split: "" %}
+  {% for pair in site.data.research %}
+    {% assign area = pair[1] %}
+    {% if area.tags %}
+      {% for t in area.tags %}
+        {% unless all_tags contains t %}
+          {% assign all_tags = all_tags | push: t %}
+        {% endunless %}
+      {% endfor %}
+    {% endif %}
+  {% endfor %}
+  {% assign all_tags = all_tags | sort_natural %}
+  {% for t in all_tags %}
+    <button class="tag-btn" data-tag="{{ t | escape }}">{{ t }}</button>
+  {% endfor %}
+</div>
 
-[**Observational Earthquake Dynamics**](/research/observational-earthquake-dynamics)
-We extract the dynamic source effects of large earthquakes in seismograms. We use and develop techniques to harness the information from arrays of seismometers. We explore theoretical and empirical ways to extract **3D Green's functions**. We use kinematic and simple dynamic model to validate theories with seismic observations. We have some focus on subduction-zone earthquakes.
+<!-- Areas Grid -->
+<div class="grid" id="areas-grid">
+  {% assign areas = "" | split: "" %}
+  {% for pair in site.data.research %}
+    {% assign area = pair[1] %}
+    {% assign areas = areas | push: area %}
+  {% endfor %}
+  {% assign areas = areas | sort: 'order' %}
 
-[**Computational Data Seismology**](/research/computational-data-seismology)
-We develop open-source Python and Julia tools for high-performance computing of correlation seismology. We develop data-flows for Cloud-based platforms through native-cloud and webservices approaches. Our tools aim to be portable and simple enough to run on laptops as well as on Cloud and HPC.
+  {% for area in areas %}
+    {% assign area_tags = area.tags | join: ' ' %}
+    <article class="card" data-tags="{{ area_tags }}">
+      {% if area.image %}
+        <img src="{{ area.image }}" alt="{{ area.title }}">
+      {% endif %}
+      <h3 id="{{ area.key }}">{{ area.title }}</h3>
+      {% if area.summary %}<p>{{ area.summary }}</p>{% endif %}
+      {% if area.links %}
+        <p class="btn-row">
+          {% for link in area.links %}
+            <a class="btn" href="{{ link.url }}">{{ link.text }}</a>
+          {% endfor %}
+        </p>
+      {% endif %}
+      {% if area.tags %}
+        <div class="tags">
+          {% for t in area.tags %}<span class="tag">{{ t }}</span>{% endfor %}
+        </div>
+      {% endif %}
+    </article>
+  {% endfor %}
+</div>
 
-[**Near-surface Seismology**](/research/near-surface-seismology)
-We explore the relations between seismic and attenuation spatio-temporal perturbations with atmospheric and geohydrological forcings. We develop proxies using our seismic measurements to groundwater levels.
+<style>
+.lead { margin-bottom: 1rem; }
+.tag-filter { display:flex; flex-wrap:wrap; gap:.5rem; margin:1rem 0 1.25rem; }
+.tag-btn { border:1px solid #e5e7eb; border-radius:999px; padding:.35rem .7rem; cursor:pointer; background:#fff; }
+.tag-btn.active { background:#111; color:#fff; border-color:#111; }
+.grid { display:grid; gap:1.25rem; grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); }
+.card { border:1px solid #eee; border-radius:14px; padding:1rem; background:#fff; }
+.card img { width:100%; height:150px; object-fit:cover; border-radius:10px; margin-bottom:.5rem; }
+.btn-row .btn { display:inline-block; margin-right:.5rem; border:1px solid #e5e7eb; border-radius:8px; padding:.35rem .6rem; text-decoration:none; }
+.tags { margin-top:.5rem; }
+.tag { font-size:.8rem; background:#f5f5f5; padding:.2rem .5rem; border-radius:999px; margin-right:.25rem; }
+</style>
 
-[**Machine Learning in Seismology**](/research/machine-learning-in-seismology)
-We develop machine learning tools for various applications in Earthquake Sciences: earthquake detection, location, phase picking, wavefield separation, time series forecast, early warning toy systems.
-
-### ... and more.
-
-### Note below: pages from the old group website
-----
-
-[**Ground Motions**](/research/ground-motions)
-
-[**High-Performance Seismology**](/research/high-performance-seismology)
-
-[**Near-surface Seismology**](/research/near-surface-seismology)
-
-[**Seismic Monitoring of the Environment**](/research/seismic-monitoring-of-the-environment)
+<script>
+(function() {
+  const buttons = Array.from(document.querySelectorAll('#tag-filter .tag-btn'));
+  const cards = Array.from(document.querySelectorAll('#areas-grid .card'));
+  function apply(tag) {
+    cards.forEach(card => {
+      const tags = (card.getAttribute('data-tags') || '').toLowerCase().split(/\s+/);
+      const show = (tag === '__all') || tags.includes(tag);
+      card.style.display = show ? '' : 'none';
+    });
+    buttons.forEach(b => b.classList.toggle('active', b.dataset.tag.toLowerCase() === tag));
+  }
+  buttons.forEach(b => b.addEventListener('click', () => apply(b.dataset.tag.toLowerCase())));
+  // allow /research/#ai to filter on load
+  const initial = (location.hash || '').replace('#','').toLowerCase();
+  if (initial) apply(initial);
+})();
+</script>

--- a/_pages/research_old.md
+++ b/_pages/research_old.md
@@ -1,0 +1,35 @@
+---
+layout: page
+title: Research (Old)
+permalink: /research/old/
+---
+
+# Research
+
+[**Ambient Noise Seismology**](/research/ambient-noise-seismology)
+We use 100s of TB of ambient seismic noise from seismic stations, cross correlate signals using single and multiple station approaches to get a time-dependent estimate of the Earth response. We use these estimates to **predict ground motions** for future earthquakes and image the Earth subsurface. We also use their time dependence evaluate the **changes in the subsurface** due to effects ranging from **earthquake damage** (short time scales), seasonal climate effects, and **long-term hydrological effects**. 
+
+[**Observational Earthquake Dynamics**](/research/observational-earthquake-dynamics)
+We extract the dynamic source effects of large earthquakes in seismograms. We use and develop techniques to harness the information from arrays of seismometers. We explore theoretical and empirical ways to extract **3D Green's functions**. We use kinematic and simple dynamic model to validate theories with seismic observations. We have some focus on subduction-zone earthquakes.
+
+[**Computational Data Seismology**](/research/computational-data-seismology)
+We develop open-source Python and Julia tools for high-performance computing of correlation seismology. We develop data-flows for Cloud-based platforms through native-cloud and webservices approaches. Our tools aim to be portable and simple enough to run on laptops as well as on Cloud and HPC.
+
+[**Near-surface Seismology**](/research/near-surface-seismology)
+We explore the relations between seismic and attenuation spatio-temporal perturbations with atmospheric and geohydrological forcings. We develop proxies using our seismic measurements to groundwater levels.
+
+[**Machine Learning in Seismology**](/research/machine-learning-in-seismology)
+We develop machine learning tools for various applications in Earthquake Sciences: earthquake detection, location, phase picking, wavefield separation, time series forecast, early warning toy systems.
+
+### ... and more.
+
+### Note below: pages from the old group website
+----
+
+[**Ground Motions**](/research/ground-motions)
+
+[**High-Performance Seismology**](/research/high-performance-seismology)
+
+[**Near-surface Seismology**](/research/near-surface-seismology)
+
+[**Seismic Monitoring of the Environment**](/research/seismic-monitoring-of-the-environment)


### PR DESCRIPTION
## Summary
- archive previous research page to `/research/old/`
- add data-driven research page sourced from `_data/research` YAML files
- provide reusable research preview include and standalone preview page
- embed preview section and scroll-reveal script on home page

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_68c09306227c832a9106761b81905035